### PR TITLE
feat: basic setup for end scene for game

### DIFF
--- a/src/scenes/scene-action.js
+++ b/src/scenes/scene-action.js
@@ -34,7 +34,7 @@ export default class ActionScene extends Phaser.Scene {
         UIs.setAudioBar(this, this.player, this.audioBar, this.game);
     }
     update(time, delta) {
-    UIs.setAudioUpdate(this);
+        UIs.setAudioUpdate(this);
         if (!this.loseSequenceActive) {
             if (this.player.sprite.x > this.chunks[this.chunks.length - 1].x - TileSettings.TileChunkDefaultSize) {
                 this.setChunk(this.chunks[this.chunks.length - 1].x + TileSettings.TileChunkDefaultSize, 0, true);

--- a/src/scenes/scene-end.js
+++ b/src/scenes/scene-end.js
@@ -1,0 +1,21 @@
+import Resources from "../utilities/utility-resources.js"
+import UIs from "../utilities/utility-uis.js"
+export default class EndScene extends Phaser.Scene {
+    constructor() {
+        super({ key: 'EndScene' });
+    }
+    preload() {
+        Resources.createResources(this);
+    }
+    create() {
+        const { ENTER, SPACE } = Phaser.Input.Keyboard.KeyCodes;
+        this.keys = this.input.keyboard.addKeys({ enter: ENTER, space: SPACE });
+        Resources.createBackgrounds(this, "image-background");
+    }
+    update() {
+        const { keys } = this;
+        if (Phaser.Input.Keyboard.JustDown(keys.enter) || Phaser.Input.Keyboard.JustDown(keys.enter)) {
+            console.log("Scene return press");
+        }
+    }
+}

--- a/src/script-game.js
+++ b/src/script-game.js
@@ -1,13 +1,14 @@
 import InitScene from "./scenes/scene-init.js";
 import GuideScene from "./scenes/scene-guide.js";
 import ActionScene from "./scenes/scene-action.js";
+import EndScene from "./scenes/scene-end.js";
 const game = new Phaser.Game({
     parent: "game",
     type: Phaser.AUTO,
     width: 120,
     height: 72,
     pixelArt: true,
-    scene: [InitScene, ActionScene, GuideScene],
+    scene: [InitScene, ActionScene, GuideScene, EndScene],
     physics: {
         default: "arcade",
         arcade: {

--- a/src/utilities/utility-helpers.js
+++ b/src/utilities/utility-helpers.js
@@ -75,7 +75,13 @@ export class Helpers {
                         this.setLoseSequence(scene, currentStage, time * 200, byFall);
                         break;
                     default:
-                        scene.scene.restart();
+                        console.log(scene.lifeBarCounter);
+                        if (scene.lifeBarCounter > 1) {
+                            scene.scene.restart();
+                        } else {
+                            scene.scene.stop('ActionScene');
+                            scene.scene.start('EndScene');
+                        }
                 }
             }
         }, [], this);


### PR DESCRIPTION
This change adds a basic end scene for when all player lives are depleted. By default the player has five lives however when all five lives are depleted, the game will end and it will shift to a new scene. For now, the scene is blank. 