### PR TITLE
feat: add setScoreCounter & setScoreRegister

### DIFF
--- a/src/utilities/utility-helpers.js
+++ b/src/utilities/utility-helpers.js
@@ -125,5 +125,15 @@ export class Helpers {
         }
         return currentScoreCounter;
     }
+    static setScoreRegister = (settingsReference, counterValue) => {
+        if (settingsReference.get('settingScoreSet') === undefined) {
+            settingsReference.set('settingScoreSet', []);
+        }
+        let scoreSetting = settingReference.get('settingScoreSet');
+        if (counterValue != undefined && counterValue != null) {
+            scoreSetting.push(counterValue);
+            settingsReference.set('settingScoreSet', scoreSetting);
+        }
+    }
 }
 

--- a/src/utilities/utility-helpers.js
+++ b/src/utilities/utility-helpers.js
@@ -115,5 +115,15 @@ export class Helpers {
             });
         }
     }
+    static setScoreCounter = (counterReference) => {
+        let currentScoreCounter = 0;
+        for (let i = 0; i < counterReference[0]; i++) {
+            currentScoreCounter = currentScoreCounter + 10;
+        }
+        for (let j = 0; j < counterReference[1]; j++) {
+            currentScoreCounter = currentScoreCounter + 1;
+        }
+        return currentScoreCounter;
+    }
 }
 


### PR DESCRIPTION
This change adds the helper functions required for tracking the player score. This functions are to be integrated into the lose sequence so that the active score is saved for each life. At the end of the game these scores are to be tallied. 