### PR TITLE
fix: adjust scene resets and transitions on player lose sequence

### DIFF
--- a/src/scenes/scene-end.js
+++ b/src/scenes/scene-end.js
@@ -17,8 +17,6 @@ export default class EndScene extends Phaser.Scene {
         UIs.setBannerWording(this, "image-finalcount", 13);
         UIs.setBannerWording(this, "image-total", 32);
         UIs.setFinalCounter(this, this.game.registry);
-        this.game.registry.set('settingLiveCounter', null);
-        this.game.registry.set('settingLiveRemoved', null);
     }
     update() {
         const { keys } = this;

--- a/src/scenes/scene-init.js
+++ b/src/scenes/scene-init.js
@@ -1,5 +1,6 @@
 import Resources from "../utilities/utility-resources.js"
 import UIs from "../utilities/utility-uis.js"
+import { Helpers } from "../utilities/utility-helpers.js";
 export default class InitScene extends Phaser.Scene {
     constructor() {
         super({ key: 'InitScene' });
@@ -14,6 +15,7 @@ export default class InitScene extends Phaser.Scene {
         UIs.setTitleResource(this);
         UIs.setButtonInput(this, this.buttonPlay, this.scene.key, 'ActionScene');
         UIs.setButtonInput(this, this.buttonGuide, this.scene.key, 'GuideScene');
+        Helpers.setSettingReset(this.game.registry);
     }
     update() {
         const { keys } = this;

--- a/src/utilities/utility-helpers.js
+++ b/src/utilities/utility-helpers.js
@@ -139,5 +139,10 @@ export class Helpers {
             settingsReference.set('settingScoreSet', scoreSetting);
         }
     }
+    static setSettingReset = (settingReference) => {
+        settingReference.set('settingLiveCounter', null);
+        settingReference.set('settingScoreSet', null);
+        settingReference.set('settingLiveRemoved', null);
+    }
 }
 

--- a/src/utilities/utility-helpers.js
+++ b/src/utilities/utility-helpers.js
@@ -58,7 +58,12 @@ export class Helpers {
                 } else {
                     let counter = this.setScoreCounter(scene.hudCounters);
                     this.setScoreRegister(scene.game.registry, counter);
-                    scene.scene.restart();
+		    if (scene.lifeBarCounter > 1) {
+		        scene.scene.restart();
+		    } else {
+		        scene.scene.stop(scene.scene.key);
+		        scene.scene.start('EndScene');
+		    }
                 }
             } else {
                 switch (currentStage) {


### PR DESCRIPTION
This change addresses some needed fixes for when the player loses the game and for when lives are depleted in specific sequences. When a player loses by falling, the game did not initially check the live counter before transitioning to an end scene, now it will check as it does when the player loses by collision. 