### PR TITLE
feat: add toggle visibility and correction for guide init on the slides

### DIFF
--- a/src/scenes/scene-guide.js
+++ b/src/scenes/scene-guide.js
@@ -18,7 +18,7 @@ export default class GuideScene extends Phaser.Scene {
         UIs.setSlideButtonInput(this, this.buttonPrev, false);
         UIs.setBannerResource(this);
         UIs.setBannerWording(this, "image-controlguide", 13);
-        UIs.setGuideResource(this);
+        UIs.setGuideResource(this, true);
     }
     update() {
         const { keys } = this;

--- a/src/utilities/utility-uis.js
+++ b/src/utilities/utility-uis.js
@@ -156,17 +156,23 @@ export default class UIs {
                 scene.slideBanner3.setVisible(true);
                 scene.slideBanner2.setVisible(false);
                 scene.slideBanner1.setVisible(false);
+                scene.buttonPrev.setVisible(true);
+                scene.buttonNext.setVisible(false);
             break;
             case 2:
                 scene.slideBanner3.setVisible(false);
                 scene.slideBanner2.setVisible(true);
                 scene.slideBanner1.setVisible(false);
+                scene.buttonPrev.setVisible(true);
+                scene.buttonNext.setVisible(true);
             break;
             case 1:
             default:
                 scene.slideBanner3.setVisible(false);
                 scene.slideBanner2.setVisible(false);
                 scene.slideBanner1.setVisible(true);
+                scene.buttonPrev.setVisible(false);
+                scene.buttonNext.setVisible(true);
         }
     }
     static setBannerResource = (scene) => {

--- a/src/utilities/utility-uis.js
+++ b/src/utilities/utility-uis.js
@@ -143,10 +143,9 @@ export default class UIs {
         scene.buttonPlay = scene.add.image(centerX, 43, "image-playbutton").setOrigin(0.5, 0).setScrollFactor(0).setDepth(100);
         scene.buttonGuide = scene.add.image(centerX, 53, "image-guidebutton").setOrigin(0.5, 0).setScrollFactor(0).setDepth(100);
     }
-    static setGuideResource = (scene) => {
+    static setGuideResource = (scene, runGuideInit) => {
         const centerX = scene.cameras.main.width / 2;
-        if (scene.slideBanner1 == undefined || scene.slideBanner2 == undefined || scene.slideBanner3 == undefined || 
-            scene.slideBanner1 == null || scene.slideBanner2 == null || scene.slideBanner3 == null) {
+        if (runGuideInit === true) {
             scene.slideBanner1 = scene.add.image(centerX, 22, "image-slide1").setOrigin(0.5, 0).setScrollFactor(0).setDepth(100);
             scene.slideBanner2 = scene.add.image(centerX, 22, "image-slide2").setOrigin(0.5, 0).setScrollFactor(0).setDepth(100);
             scene.slideBanner3 = scene.add.image(centerX, 22, "image-slide3").setOrigin(0.5, 0).setScrollFactor(0).setDepth(100);
@@ -210,7 +209,7 @@ export default class UIs {
                     scene.slideCount = 1;
                 }
             }
-            utilityContext.setGuideResource(scene);
+            utilityContext.setGuideResource(scene, false);
         });
     }
 }


### PR DESCRIPTION
This change toggles the visibility of the next and previous buttons based on the first and last slide. In addition, there was a bug where if the back button was pressed the slides would disappear if the guide scene was re-opened. This was due to the slide objects not being null on the next initialization. A simple fix is to add an init check in-lieu of the null check on the resource functions. 